### PR TITLE
line_log_parser: changed date creating

### DIFF
--- a/src/Parser/LineLogParser.php
+++ b/src/Parser/LineLogParser.php
@@ -35,7 +35,11 @@ class LineLogParser implements LogParserInterface
         if (!isset($data['date'])) {
             return array();
         }
-        $date = DateTime::createFromFormat($dateFormat, $data['date']);
+        try {
+            $date = new DateTime($data['date']);
+        } catch (Exception $e) {
+            $date = false;
+        }
 
         $array = array(
             'date'    => $date,


### PR DESCRIPTION
current date creating fails on monolog date format: **2022-12-14T13:22:40.887197+01:00**
format setting is used for date creating and further on is not used as templates specifies date format display.

my config is:
```
evo_log_viewer:
   show_app_logs: true
```
